### PR TITLE
Added unified discord notification

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,64 +46,45 @@ jobs:
               echo "discord_mention=<@1362087975906967736>" >> $GITHUB_OUTPUT ;;
           esac
 
+  determine_event_type:
+    name: Determine Discord Event Type
+    runs-on: ubuntu-latest
+    needs: [gitleaks, trivy_scan]
+    outputs:
+      event_type: ${{ steps.set_type.outputs.event_type }}
+    steps:
+      - id: set_type
+        run: |
+          # Determine event priority
+          if [ "${{ needs.gitleaks.result }}" == "failure" ]; then
+            echo "event_type=gitleaks_failed" >> $GITHUB_OUTPUT
+
+          elif [ "${{ needs.trivy_scan.outputs.has_findings }}" == "true" ]; then
+            echo "event_type=trivy_vulnerabilities" >> $GITHUB_OUTPUT
+
+          else
+            echo "event_type=success" >> $GITHUB_OUTPUT
+          fi
+
   send_discord_notification:
     name: Unified Discord Notification
-    runs-on: ubuntu-latest
-    needs: [gitleaks, trivy_scan, map_pr_to_discord]
+    needs: [
+      gitleaks,
+      trivy_scan,
+      map_pr_to_discord,
+      determine_event_type
+    ]
     if: always()
-    steps:
-      - name: Determine message type
-        id: decide
-        run: |
-          gitleaks_result="${{ needs.gitleaks.result }}"
-          trivy_findings="${{ needs.trivy_scan.outputs.has_findings }}"
-          type="none"
-          if [ "$gitleaks_result" == "failure" ]; then
-            type="gitleaks_failed"
-          elif [ "$trivy_findings" == "true" ]; then
-            type="trivy_vulnerabilities"
-          fi
-          echo "type=$type" >> $GITHUB_OUTPUT
-
-      - name: Send Discord Notification
-        if: steps.decide.outputs.type != 'none'
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          DISCORD_MENTION: ${{ needs.map_pr_to_discord.outputs.discord_mention }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          case "${{ steps.decide.outputs.type }}" in
-            gitleaks_failed)
-              MESSAGE=":x: **Peer Website Gitleaks Scan Failed!**\n"
-              MESSAGE+="**PR:** $PR_TITLE\n"
-              MESSAGE+="PR Link: <$PR_URL>\n"
-              MESSAGE+="CI Run: <$RUN_URL>\n"
-              MESSAGE+="Author: $DISCORD_MENTION\n\n"
-              MESSAGE+=":warning: **Secrets were detected by Gitleaks**\n"
-              MESSAGE+="You can:\n"
-              MESSAGE+="- [Click here to view workflow artifacts](<$RUN_URL>) (download the **gitleaks-report** artifact)\n"
-              MESSAGE+="- Check the **Actions → Artifacts** tab to view/download the report\n\n"
-              MESSAGE+=":no_entry: **Reminder:** Do NOT bypass with \`git commit --no-verify\`. CI will still block your PR.\n"
-              MESSAGE+="If this secret is actually required (false positive or approved usage), contact **CTO / Team Lead / DevOps** to whitelist it."
-              ;;
-            trivy_vulnerabilities)
-              MESSAGE="**Trivy found HIGH or CRITICAL vulnerabilities in Peer Website!**\n"
-              MESSAGE+="**Do NOT ignore this finding — inform your Team Lead or CTO immediately.**\n"
-              MESSAGE+="View the **Trivy report artifact** in the Actions run for full details.\n"
-              MESSAGE+="**PR:** $PR_TITLE\n"
-              MESSAGE+="Link: <$PR_URL>\n"
-              MESSAGE+="Run: <$RUN_URL>\n"
-              MESSAGE+="Author: $DISCORD_MENTION\n\n"
-              MESSAGE+="<@298135800804278274> <@1362087975906967736> <@1334087880833892392>"
-              ;;
-          esac
-
-          curl -H "Content-Type: application/json" \
-               -X POST \
-               -d "{\"content\": \"$MESSAGE\"}" \
-               "$DISCORD_WEBHOOK_URL"
+    uses: peer-network/.github/.github/workflows/discord-notify.yml@main
+    with:
+      repo_name: "Web Frontend"
+      event_type: ${{ needs.determine_event_type.outputs.event_type }}
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_url: ${{ github.event.pull_request.html_url }}
+      run_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      discord_mention: ${{ needs.map_pr_to_discord.outputs.discord_mention }}
+    secrets:
+      webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
   final_check:
     name: Final Check - Fail if Any Critical Job Failed


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This PR standardizes CI notifications for this repository by integrating the centralized reusable Discord notification workflow used across all frontend repos. The goal is to unify Gitleaks and Trivy alert formatting and ensure consistent communication for security-related PR checks.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Added determine_event_type job to classify CI results (gitleaks, trivy, success)

Integrated the shared discord-notify.yml reusable workflow

Replaced local message-building logic with standardized notifications

Ensured correct PR author → Discord mapping and Web Frontend team lead tagging

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Updated .github/workflows/security.yml to include determine_event_type and send_discord_notification

Removed custom inline notifications, replaced with centralized workflow call

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->
This brings this repo in line with the Web, Android, and iOS frontend CI standards.


### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
